### PR TITLE
Ignore bundle generated file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,4 +59,9 @@ typings/
 
 # next.js build output
 .next
+
+# Mac specific file
 .DS_Store
+
+# generated files
+bundle.js


### PR DESCRIPTION
I just added `bundle.js` file to the ignore list, since we don't need it in our repo. It's a generated file 😁